### PR TITLE
Git tidy

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -50,7 +50,10 @@ func Middleware(repoDir string, gh GitHooks) wish.Middleware {
 			cmd := s.Command()
 			if len(cmd) == 2 {
 				gc := cmd[0]
-				repo := cmd[1][1:] // cmd[1] will be `/REPO`
+				repo := cmd[1] // cmd[1] will be `/REPO`
+				if len(repo) > 0 && repo[0] == '/' {
+					repo = repo[1:]
+				}
 				pk := s.PublicKey()
 				access := gh.AuthRepo(repo, pk)
 				switch gc {


### PR DESCRIPTION
* remove unused code
* use go-git when bare init
* sanitize repo name

This allows cloning repos using more "natural" git url schemes such as `git@git.charm.sh:soft-serve`