### PR TITLE
feat: ttl middleware

### DIFF
--- a/ttl/ttl.go
+++ b/ttl/ttl.go
@@ -1,0 +1,27 @@
+// Package ttl provides a middleware to put a TTL to a session.
+package ttl
+
+import (
+	"log"
+	"time"
+
+	"github.com/charmbracelet/wish"
+	"github.com/gliderlabs/ssh"
+)
+
+// Middleware that sends a SIGTERM to connections after the given time.
+func Middleware(ttl time.Duration) wish.Middleware {
+	return func(sh ssh.Handler) ssh.Handler {
+		return func(s ssh.Session) {
+			go func() {
+				time.Sleep(ttl)
+				log.Println("reached ttl, closing session")
+				if err := s.CloseWrite(); err != nil {
+					log.Printf("failed to close session: %v", err)
+				}
+				s.Exit(15)
+			}()
+			sh(s)
+		}
+	}
+}

--- a/ttl/ttl_test.go
+++ b/ttl/ttl_test.go
@@ -1,0 +1,53 @@
+package ttl_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/wish/testsession"
+	"github.com/charmbracelet/wish/ttl"
+	"github.com/gliderlabs/ssh"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+const expectedTimeoutErr = "Process exited with status 15"
+const msg1 = "message 1"
+const msg2 = "message 2"
+
+func TestMiddleware(t *testing.T) {
+	t.Run("timedOut", func(t *testing.T) {
+		sess := setup(t, time.Millisecond)
+		bts, err := sess.CombinedOutput("")
+		t.Log(string(bts))
+		if err == nil || err.Error() != expectedTimeoutErr {
+			t.Errorf("expected error %q, got %v", expectedTimeoutErr, err)
+		}
+		if string(bts) != msg1 {
+			t.Errorf("expected output %q, got %q", msg1, string(bts))
+		}
+	})
+
+	t.Run("do not timeout", func(t *testing.T) {
+		sess := setup(t, 15*time.Millisecond)
+		bts, err := sess.CombinedOutput("")
+		t.Log(string(bts))
+		if err != nil {
+			t.Errorf("expected no errors, got %v", err)
+		}
+		if string(bts) != msg1+msg2 {
+			t.Errorf("expected output %q, got %q", msg1, string(bts))
+		}
+	})
+}
+
+func setup(t *testing.T, d time.Duration) *gossh.Session {
+	session, _, cleanup := testsession.New(t, &ssh.Server{
+		Handler: ttl.Middleware(d)(func(s ssh.Session) {
+			s.Write([]byte(msg1))
+			time.Sleep(time.Millisecond * 10)
+			s.Write([]byte(msg2))
+		}),
+	}, nil)
+	t.Cleanup(cleanup)
+	return session
+}


### PR DESCRIPTION
users can use `ttl.Middleware(10*time.Minute)`, for example, to set a 10m max life for a SSH session.