### PR TITLE
fix: improve accesscontrol and activeterm middlewares

### DIFF
--- a/accesscontrol/accesscontrol.go
+++ b/accesscontrol/accesscontrol.go
@@ -2,6 +2,8 @@
 package accesscontrol
 
 import (
+	"fmt"
+
 	"github.com/charmbracelet/wish"
 	"github.com/gliderlabs/ssh"
 )
@@ -21,6 +23,7 @@ func Middleware(cmds ...string) wish.Middleware {
 					return
 				}
 			}
+			fmt.Fprintln(s, "Command is not allowed: "+s.Command()[0])
 			s.Exit(1)
 		}
 	}

--- a/accesscontrol/accesscontrol_test.go
+++ b/accesscontrol/accesscontrol_test.go
@@ -1,6 +1,7 @@
 package accesscontrol_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/charmbracelet/wish/accesscontrol"
@@ -12,10 +13,11 @@ import (
 const out = "hello world"
 
 func TestMiddleware(t *testing.T) {
-	requireEmpty := func(tb testing.TB, s string) {
+	requireDenied := func(tb testing.TB, s, cmd string) {
 		tb.Helper()
-		if s != "" {
-			tb.Errorf("expected output to be empty, got %q", s)
+		expected := fmt.Sprintf("Command is not allowed: %s\n", cmd)
+		if s != expected {
+			t.Errorf("expected %q, got %q", expected, s)
 		}
 	}
 
@@ -39,7 +41,7 @@ func TestMiddleware(t *testing.T) {
 		if err == nil {
 			t.Errorf("should have errored")
 		}
-		requireEmpty(t, string(out))
+		requireDenied(t, string(out), "echo")
 	})
 
 	t.Run("allowed cmds no cmd", func(t *testing.T) {
@@ -63,7 +65,7 @@ func TestMiddleware(t *testing.T) {
 		if err == nil {
 			t.Error(err)
 		}
-		requireEmpty(t, string(out))
+		requireDenied(t, string(out), "cat")
 	})
 
 	t.Run("allowed cmds with allowed cmd followed disallowed cmd", func(t *testing.T) {
@@ -71,7 +73,7 @@ func TestMiddleware(t *testing.T) {
 		if err == nil {
 			t.Error(err)
 		}
-		requireEmpty(t, string(out))
+		requireDenied(t, string(out), "cat")
 	})
 }
 

--- a/activeterm/activeterm.go
+++ b/activeterm/activeterm.go
@@ -2,6 +2,8 @@
 package activeterm
 
 import (
+	"fmt"
+
 	"github.com/charmbracelet/wish"
 	"github.com/gliderlabs/ssh"
 )
@@ -12,6 +14,7 @@ func Middleware() wish.Middleware {
 		return func(s ssh.Session) {
 			_, _, active := s.Pty()
 			if !active {
+				fmt.Fprintln(s, "Requires an active PTY")
 				s.Exit(1)
 				return
 			}

--- a/activeterm/activeterm_test.go
+++ b/activeterm/activeterm_test.go
@@ -11,8 +11,12 @@ import (
 
 func TestMiddleware(t *testing.T) {
 	t.Run("inactive term", func(t *testing.T) {
-		if err := setup(t).Run(""); err == nil {
+		out, err := setup(t).Output("")
+		if err == nil {
 			t.Errorf("tests should be an inactive pty")
+		}
+		if string(out) != "Requires an active PTY\n" {
+			t.Errorf("invalid output: %q", string(out))
 		}
 	})
 }


### PR DESCRIPTION
say what's wrong instead of just exiting 1