### PR TITLE
fix: examples showing how to properly shutdown the server

### DIFF
--- a/examples/bubbletea/main.go
+++ b/examples/bubbletea/main.go
@@ -4,11 +4,13 @@ package main
 // and continually print up to date terminal information.
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/wish"
@@ -44,7 +46,9 @@ func main() {
 
 	<-done
 	log.Println("Stopping SSH server")
-	if err := s.Close(); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer func() { cancel() }()
+	if err := s.Shutdown(ctx); err != nil {
 		log.Fatalln(err)
 	}
 }

--- a/examples/git/main.go
+++ b/examples/git/main.go
@@ -4,12 +4,14 @@ package main
 // directly to the server. To test `ssh -p 23233 localhost` once it's running.
 
 import (
+	"context"
 	"fmt"
 	"io/fs"
 	"log"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/charmbracelet/wish"
 	gm "github.com/charmbracelet/wish/git"
@@ -75,7 +77,9 @@ func main() {
 
 	<-done
 	log.Println("Stopping SSH server")
-	if err := s.Close(); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer func() { cancel() }()
+	if err := s.Shutdown(ctx); err != nil {
 		log.Fatalln(err)
 	}
 }


### PR DESCRIPTION
refs #16

using `Close` directly kills connections and may leave the terminal may not be restored