### PR TITLE
refactor: rename BubbleTeaHandler to Handler

### DIFF
--- a/bubbletea/tea.go
+++ b/bubbletea/tea.go
@@ -15,7 +15,7 @@ import (
 // start it with the tea.ProgramOptions returned.
 //
 // Deprecated: use Handler instead.
-type BubbleTeaHandler func(ssh.Session) (tea.Model, []tea.ProgramOption)
+type BubbleTeaHandler func(ssh.Session) (tea.Model, []tea.ProgramOption) // nolint: revive
 
 // Hander is the function Bubble Tea apps implement to hook into the
 // SSH Middleware. This will create a new tea.Program for every connection and

--- a/bubbletea/tea.go
+++ b/bubbletea/tea.go
@@ -13,13 +13,20 @@ import (
 // BubbleTeaHander is the function Bubble Tea apps implement to hook into the
 // SSH Middleware. This will create a new tea.Program for every connection and
 // start it with the tea.ProgramOptions returned.
+//
+// Deprecated: use Handler instead.
 type BubbleTeaHandler func(ssh.Session) (tea.Model, []tea.ProgramOption)
 
-// Middleware takes a BubbleTeaHandler and hooks the input and output for the
+// Hander is the function Bubble Tea apps implement to hook into the
+// SSH Middleware. This will create a new tea.Program for every connection and
+// start it with the tea.ProgramOptions returned.
+type Handler = BubbleTeaHandler
+
+// Middleware takes a Handler and hooks the input and output for the
 // ssh.Session into the tea.Program. It also captures window resize events and
 // sends them to the tea.Program as tea.WindowSizeMsgs. By default a 256 color
 // profile will be used when rendering with Lip Gloss.
-func Middleware(bth BubbleTeaHandler) wish.Middleware {
+func Middleware(bth Handler) wish.Middleware {
 	return MiddlewareWithColorProfile(bth, termenv.ANSI256)
 }
 
@@ -27,7 +34,7 @@ func Middleware(bth BubbleTeaHandler) wish.Middleware {
 // returned by the server when using Lip Gloss. The number of colors supported
 // by an SSH client's terminal cannot be detected by the server but this will
 // allow for manually setting the color profile on all SSH connections.
-func MiddlewareWithColorProfile(bth BubbleTeaHandler, cp termenv.Profile) wish.Middleware {
+func MiddlewareWithColorProfile(bth Handler, cp termenv.Profile) wish.Middleware {
 	return func(sh ssh.Handler) ssh.Handler {
 		lipgloss.SetColorProfile(cp)
 		return func(s ssh.Session) {


### PR DESCRIPTION
this fixes a lint issue and also makes usage a bit nicer, instead of 

```go
bubbletea.BubbleTeaHandler()
```

you can use

```go
bubbletea.Handler()
```

directly, which reads a bit less repetitive.

This change is backwards-compatible with previous versions. 🙏