### PR TITLE
feat: exit session after handling git commands

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -85,6 +85,7 @@ func Middleware(repoDir string, gh Hooks) wish.Middleware {
 					default:
 						fatalGit(s, ErrNotAuthed)
 					}
+					return
 				case "git-upload-archive", "git-upload-pack":
 					switch access {
 					case ReadOnlyAccess, ReadWriteAccess, AdminAccess:
@@ -100,6 +101,7 @@ func Middleware(repoDir string, gh Hooks) wish.Middleware {
 					default:
 						fatalGit(s, ErrNotAuthed)
 					}
+					return
 				}
 			}
 			sh(s)


### PR DESCRIPTION
we don't need to worry about executing other middleware if git
middleware picks up a receive/upload command