### PR TITLE
docs: add a simple wish app example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 examples/*
+!examples/simple
 !examples/bubbletea
 examples/bubbletea/bubbletea
 examples/bubbletea/.ssh

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/charmbracelet/wish"
+	"github.com/charmbracelet/wish/logging"
+	"github.com/gliderlabs/ssh"
+)
+
+const (
+	host = "localhost"
+	port = 23234
+)
+
+func main() {
+	s, err := wish.NewServer(
+		wish.WithAddress(fmt.Sprintf("%s:%d", host, port)),
+		wish.WithHostKeyPath(".ssh/term_info_ed25519"),
+		wish.WithMiddleware(
+			func(h ssh.Handler) ssh.Handler {
+				return func(s ssh.Session) {
+					fmt.Fprintln(s, "Hello, world!")
+					h(s)
+				}
+			},
+			logging.Middleware(),
+		),
+	)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	done := make(chan os.Signal, 1)
+	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+	log.Printf("Starting SSH server on %s:%d", host, port)
+	go func() {
+		if err = s.ListenAndServe(); err != nil {
+			log.Fatalln(err)
+		}
+	}()
+
+	<-done
+	log.Println("Stopping SSH server")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer func() { cancel() }()
+	if err := s.Shutdown(ctx); err != nil {
+		log.Fatalln(err)
+	}
+}


### PR DESCRIPTION
this adds a simple wish app example, with no bubbletea or anything else,
so it can be easily copied and extended.
