### PR TITLE
fix: EOL when force-closing the connection

### DIFF
--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -26,7 +26,7 @@ func main() {
 		wish.WithMiddleware(
 			func(h ssh.Handler) ssh.Handler {
 				return func(s ssh.Session) {
-					wish.Println(s, "Hello world!")
+					fmt.Fprintln(s, "Hello, world!")
 					h(s)
 				}
 			},

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -26,7 +26,7 @@ func main() {
 		wish.WithMiddleware(
 			func(h ssh.Handler) ssh.Handler {
 				return func(s ssh.Session) {
-					fmt.Fprintln(s, "Hello, world!")
+					wish.Println(s, "Hello world!")
 					h(s)
 				}
 			},

--- a/wish.go
+++ b/wish.go
@@ -47,6 +47,8 @@ func Fatal(s ssh.Session, v ...interface{}) {
 
 // Fatalf formats according to the given format, prints to the session's STDERR
 // followed by an exit 1.
+//
+// Notice that this might cause formatting issues if you don't add a \r\n in the end of your string.
 func Fatalf(s ssh.Session, f string, v ...interface{}) {
 	Errorf(s, f, v...)
 	_ = s.Exit(1)
@@ -54,9 +56,10 @@ func Fatalf(s ssh.Session, f string, v ...interface{}) {
 }
 
 // Fatalln formats according to the default format, prints to the session's
-// STDERR followed by an exit 1.
+// STDERR, followed by a new line and an exit 1.
 func Fatalln(s ssh.Session, v ...interface{}) {
 	Errorln(s, v...)
+	Errorf(s, "\r")
 	_ = s.Exit(1)
 	_ = s.Close()
 }


### PR DESCRIPTION
It seems that forcing an early `session.Exit` might cause formatting issues if a `\r` is not printed as well.

I'm not sure why this happens, but this seems to fix it.

Screenshot of the problem happening:

![image](https://user-images.githubusercontent.com/245435/172238993-fca27100-3ff4-4c75-a28a-2030179c6de9.png)
