### PR TITLE
fix(scp): do not proceed chain

### DIFF
--- a/scp/scp.go
+++ b/scp/scp.go
@@ -84,8 +84,6 @@ func Middleware(rh CopyToClientHandler, wh CopyFromClientHandler) wish.Middlewar
 				wish.Fatal(s, err)
 				return
 			}
-
-			sh(s)
 		}
 	}
 }


### PR DESCRIPTION
If you wanna serve scp requests and other commands as well in the same server, when a scp request happens, nothing else should be executed after that.

if, say, we run scp, and then handler over to a cobra app, it'll print stuff to stdout, which will make the scp command fail with something like:

```
protocol error: expected control record
```

if the command is not scp, it will still proceed to then next item in the chain, so that should not be an issue.
