### PR TITLE
fix: goroutine leak

### DIFF
--- a/bubbletea/tea.go
+++ b/bubbletea/tea.go
@@ -77,6 +77,7 @@ func MiddlewareWithProgramHandler(bth ProgramHandler, cp termenv.Profile) wish.M
 						case <-s.Context().Done():
 							if p != nil {
 								p.Quit()
+								return
 							}
 						case w := <-windowChanges:
 							if p != nil {


### PR DESCRIPTION
we never really break out of that for loop, so, the goroutine would keep running there even long after the program that launched it finished.

this fixes it.