### PR TITLE
chore: avoid uneeded runs of codecov workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,24 +9,14 @@ jobs:
     uses: charmbracelet/meta/.github/workflows/build.yml@main
 
   codecov:
-    strategy:
-      matrix:
-        go-version: [~1.18, ^1]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - name: Set up Go
-        uses: actions/setup-go@v3
+      - uses: actions/setup-go@v3
         with:
-          go-version: ${{ matrix.go-version }}
-
-      - name: Build
-        run: go build -v ./...
-
-      - name: Test
-        run: go test -failfast -race -coverpkg=./... -covermode=atomic -coverprofile=coverage.txt ./... -timeout 5m
-
+          go-version: '^1'
+          cache: true
+      - run: go test -failfast -race -coverpkg=./... -covermode=atomic -coverprofile=coverage.txt ./... -timeout 5m
       - uses: codecov/codecov-action@v3
         with:
           file: ./coverage.txt


### PR DESCRIPTION
we can measure code coverage only once for linux and latest go, should be fine.