### PR TITLE
fix: properly handle server closed on examples

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,3 +32,12 @@ linters:
     - unconvert
     - unparam
     - whitespace
+    - depguard
+
+
+linters-settings:
+  depguard:
+     list-type: 'denylist'
+     packages-with-error-message:
+       - 'github.com/gliderlabs/ssh': 'use github.com/charmbracelet/ssh instead'
+

--- a/examples/bubbletea/main.go
+++ b/examples/bubbletea/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -41,7 +42,7 @@ func main() {
 	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	log.Info("Starting SSH server", "host", host, "port", port)
 	go func() {
-		if err = s.ListenAndServe(); err != nil {
+		if err = s.ListenAndServe(); err != nil && !errors.Is(err, ssh.ErrServerClosed) {
 			log.Error("could not start server", "error", err)
 		}
 	}()
@@ -50,8 +51,8 @@ func main() {
 	log.Info("Stopping SSH server")
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer func() { cancel() }()
-	if err := s.Shutdown(ctx); err != nil {
-		log.Error("could not start server", "error", err)
+	if err := s.Shutdown(ctx); err != nil && !errors.Is(err, ssh.ErrServerClosed) {
+		log.Error("could not stop server", "error", err)
 	}
 }
 

--- a/examples/bubbleteaprogram/main.go
+++ b/examples/bubbleteaprogram/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -42,7 +43,7 @@ func main() {
 	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	log.Info("Starting SSH server", "host", host, "port", port)
 	go func() {
-		if err = s.ListenAndServe(); err != nil {
+		if err = s.ListenAndServe(); err != nil && !errors.Is(err, ssh.ErrServerClosed) {
 			log.Error("could not start server", "error", err)
 		}
 	}()
@@ -51,8 +52,8 @@ func main() {
 	log.Info("Stopping SSH server")
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer func() { cancel() }()
-	if err := s.Shutdown(ctx); err != nil {
-		log.Error("could not start server", "error", err)
+	if err := s.Shutdown(ctx); err != nil && !errors.Is(err, ssh.ErrServerClosed) {
+		log.Error("could not stop server", "error", err)
 	}
 }
 

--- a/examples/cobra/main.go
+++ b/examples/cobra/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -75,7 +76,7 @@ func main() {
 	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	log.Info("Starting SSH server", "host", host, "port", port)
 	go func() {
-		if err = s.ListenAndServe(); err != nil {
+		if err = s.ListenAndServe(); err != nil && !errors.Is(err, ssh.ErrServerClosed) {
 			log.Error("could not start server", "error", err)
 		}
 	}()
@@ -84,7 +85,7 @@ func main() {
 	log.Info("Stopping SSH server")
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer func() { cancel() }()
-	if err := s.Shutdown(ctx); err != nil {
+	if err := s.Shutdown(ctx); err != nil && !errors.Is(err, ssh.ErrServerClosed) {
 		log.Error("could not stop server", "error", err)
 	}
 }

--- a/examples/git/main.go
+++ b/examples/git/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -72,7 +73,7 @@ func main() {
 	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	log.Info("Starting SSH server", "host", host, "port", port)
 	go func() {
-		if err = s.ListenAndServe(); err != nil {
+		if err = s.ListenAndServe(); err != nil && !errors.Is(err, ssh.ErrServerClosed) {
 			log.Error("could not start server", "error", err)
 		}
 	}()
@@ -81,7 +82,7 @@ func main() {
 	log.Info("Stopping SSH server")
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer func() { cancel() }()
-	if err := s.Shutdown(ctx); err != nil {
+	if err := s.Shutdown(ctx); err != nil && !errors.Is(err, ssh.ErrServerClosed) {
 		log.Error("could not stop server", "error", err)
 	}
 }

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/charmbracelet/log v0.1.2
 	github.com/charmbracelet/ssh v0.0.0-20221117183211-483d43d97103
 	github.com/charmbracelet/wish v0.5.0
-	github.com/gliderlabs/ssh v0.3.5
 	github.com/muesli/termenv v0.14.0
 	github.com/spf13/cobra v1.5.0
 )

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/log v0.1.2
 	github.com/charmbracelet/ssh v0.0.0-20221117183211-483d43d97103
 	github.com/charmbracelet/wish v0.5.0
+	github.com/gliderlabs/ssh v0.3.5
 	github.com/muesli/termenv v0.14.0
 	github.com/spf13/cobra v1.5.0
 )

--- a/examples/identity/main.go
+++ b/examples/identity/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -52,7 +53,7 @@ func main() {
 	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	log.Info("Starting SSH server", "host", host, "port", port)
 	go func() {
-		if err = s.ListenAndServe(); err != nil {
+		if err = s.ListenAndServe(); err != nil && !errors.Is(err, ssh.ErrServerClosed) {
 			log.Error("could not start server", "error", err)
 		}
 	}()
@@ -61,7 +62,7 @@ func main() {
 	log.Info("Stopping SSH server")
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer func() { cancel() }()
-	if err := s.Shutdown(ctx); err != nil {
-		log.Error("could not start server", "error", err)
+	if err := s.Shutdown(ctx); err != nil && !errors.Is(err, ssh.ErrServerClosed) {
+		log.Error("could not stop server", "error", err)
 	}
 }

--- a/examples/scp/main.go
+++ b/examples/scp/main.go
@@ -12,9 +12,9 @@ import (
 	"time"
 
 	"github.com/charmbracelet/log"
+	"github.com/charmbracelet/ssh"
 	"github.com/charmbracelet/wish"
 	"github.com/charmbracelet/wish/scp"
-	"github.com/gliderlabs/ssh"
 )
 
 const (

--- a/examples/scp/main.go
+++ b/examples/scp/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -13,6 +14,7 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/charmbracelet/wish"
 	"github.com/charmbracelet/wish/scp"
+	"github.com/gliderlabs/ssh"
 )
 
 const (
@@ -37,7 +39,7 @@ func main() {
 	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	log.Info("Starting SSH server", "host", host, "port", port)
 	go func() {
-		if err = s.ListenAndServe(); err != nil {
+		if err = s.ListenAndServe(); err != nil && !errors.Is(err, ssh.ErrServerClosed) {
 			log.Error("could not start server", "error", err)
 		}
 	}()
@@ -46,7 +48,7 @@ func main() {
 	log.Info("Stopping SSH server")
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer func() { cancel() }()
-	if err := s.Shutdown(ctx); err != nil {
+	if err := s.Shutdown(ctx); err != nil && !errors.Is(err, ssh.ErrServerClosed) {
 		log.Error("could not stop server", "error", err)
 	}
 }


### PR DESCRIPTION
this prevents leaking "the beginning" of another log line, as well as "wrong" errors (server closing is fine :)) 