### PR TITLE
fix(examples): properly shut down if failed to start

### DIFF
--- a/examples/bubbletea/main.go
+++ b/examples/bubbletea/main.go
@@ -44,6 +44,7 @@ func main() {
 	go func() {
 		if err = s.ListenAndServe(); err != nil && !errors.Is(err, ssh.ErrServerClosed) {
 			log.Error("could not start server", "error", err)
+			done <- nil
 		}
 	}()
 

--- a/examples/bubbleteaprogram/main.go
+++ b/examples/bubbleteaprogram/main.go
@@ -45,6 +45,7 @@ func main() {
 	go func() {
 		if err = s.ListenAndServe(); err != nil && !errors.Is(err, ssh.ErrServerClosed) {
 			log.Error("could not start server", "error", err)
+			done <- nil
 		}
 	}()
 

--- a/examples/cobra/main.go
+++ b/examples/cobra/main.go
@@ -78,6 +78,7 @@ func main() {
 	go func() {
 		if err = s.ListenAndServe(); err != nil && !errors.Is(err, ssh.ErrServerClosed) {
 			log.Error("could not start server", "error", err)
+			done <- nil
 		}
 	}()
 

--- a/examples/git/main.go
+++ b/examples/git/main.go
@@ -75,6 +75,7 @@ func main() {
 	go func() {
 		if err = s.ListenAndServe(); err != nil && !errors.Is(err, ssh.ErrServerClosed) {
 			log.Error("could not start server", "error", err)
+			done <- nil
 		}
 	}()
 

--- a/examples/identity/main.go
+++ b/examples/identity/main.go
@@ -55,6 +55,7 @@ func main() {
 	go func() {
 		if err = s.ListenAndServe(); err != nil && !errors.Is(err, ssh.ErrServerClosed) {
 			log.Error("could not start server", "error", err)
+			done <- nil
 		}
 	}()
 

--- a/examples/scp/main.go
+++ b/examples/scp/main.go
@@ -41,6 +41,7 @@ func main() {
 	go func() {
 		if err = s.ListenAndServe(); err != nil && !errors.Is(err, ssh.ErrServerClosed) {
 			log.Error("could not start server", "error", err)
+			done <- nil
 		}
 	}()
 

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -44,6 +44,7 @@ func main() {
 	go func() {
 		if err = s.ListenAndServe(); err != nil && !errors.Is(err, ssh.ErrServerClosed) {
 			log.Error("could not start server", "error", err)
+			done <- nil
 		}
 	}()
 


### PR DESCRIPTION
Without this change, if the server fails to start, the program will hang waiting for a signal on `done` before properly exiting.