### PR TITLE
fix(tea): set the color profile once

### DIFF
--- a/bubbletea/tea.go
+++ b/bubbletea/tea.go
@@ -65,8 +65,11 @@ func MiddlewareWithColorProfile(bth Handler, cp termenv.Profile) wish.Middleware
 // Make sure to set the tea.WithInput and tea.WithOutput to the ssh.Session
 // otherwise the program will not function properly.
 func MiddlewareWithProgramHandler(bth ProgramHandler, cp termenv.Profile) wish.Middleware {
+	// XXX: This is a hack to make sure the default Termenv output color
+	// profile is set before the program starts. Ideally, we want a Lip Gloss
+	// renderer per session.
+	lipgloss.SetColorProfile(cp)
 	return func(sh ssh.Handler) ssh.Handler {
-		lipgloss.SetColorProfile(cp)
 		return func(s ssh.Session) {
 			p := bth(s)
 			if p != nil {


### PR DESCRIPTION
Set the global color profile once out of the middleware. We don't need to set the value every time the middleware is called. This also adds a comment about the behavior.