### PR TITLE
Improve Elapsed Documentation

### DIFF
--- a/elapsed/elapsed.go
+++ b/elapsed/elapsed.go
@@ -10,7 +10,8 @@ import (
 // MiddlewareWithFormat returns a middleware that logs the elapsed time of the
 // session. It accepts a format string to print the elapsed time.
 //
-// This must be called as the last middleware in the chain.
+// In order to provide an accurate elapsed time for the entire session,
+// this must be called as the last middleware in the chain.
 func MiddlewareWithFormat(format string) wish.Middleware {
 	return func(sh ssh.Handler) ssh.Handler {
 		return func(s ssh.Session) {
@@ -23,7 +24,8 @@ func MiddlewareWithFormat(format string) wish.Middleware {
 
 // Middleware returns a middleware that logs the elapsed time of the session.
 //
-// This must be called as the last middleware in the chain.
+// In order to provide an accurate elapsed time for the entire session,
+// this must be called as the last middleware in the chain.
 func Middleware() wish.Middleware {
 	return MiddlewareWithFormat("elapsed time: %v\n")
 }


### PR DESCRIPTION
You can actually called elapsed as many times as you'd like, anywhere in the chain. In order to be most useful, you should probably call it at the end.