### PR TITLE
fix: create a new pty for exec.Cmd

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -51,12 +51,12 @@ func (c *Cmd) SetDir(dir string) {
 
 // Run runs the program and waits for it to finish.
 func (c *Cmd) Run() error {
-	ppty, _, ok := c.sess.Pty()
+	ppty, winCh, ok := c.sess.Pty()
 	if !ok {
 		c.cmd.Stdin, c.cmd.Stdout, c.cmd.Stderr = c.sess, c.sess, c.sess
 		return c.cmd.Run()
 	}
-	return c.doRun(ppty)
+	return c.doRun(ppty, winCh)
 }
 
 var _ tea.ExecCommand = &Cmd{}

--- a/cmd.go
+++ b/cmd.go
@@ -2,22 +2,11 @@ package wish
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"io"
-	"os"
 	"os/exec"
-	"os/signal"
-	"runtime"
-	"syscall"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/log"
 	"github.com/charmbracelet/ssh"
-	"github.com/creack/pty"
-	"github.com/muesli/cancelreader"
-	"golang.org/x/term"
 )
 
 // CommandContext is like Command but includes a context.
@@ -67,89 +56,7 @@ func (c *Cmd) Run() error {
 		c.cmd.Stdin, c.cmd.Stdout, c.cmd.Stderr = c.sess, c.sess, c.sess
 		return c.cmd.Run()
 	}
-
-	// especially on macOS, the slave pty is killed once exec finishes.
-	// since we're using it for the ssh session, this would render
-	// the pty and the session unusable.
-	// so, we need to create another pty, and run the Cmd on it instead.
-	ptmx, err := pty.Start(c.cmd)
-	if err != nil {
-		return fmt.Errorf("cmd: %w", err)
-	}
-	defer func() {
-		if err := ptmx.Close(); err != nil {
-			log.Warn("could not close pty", "err", err)
-		}
-	}()
-
-	// setup resizes
-	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, syscall.SIGWINCH)
-	go func() {
-		for range ch {
-			if err := pty.InheritSize(ppty.Master, ptmx); err != nil {
-				log.Warn("error resizing pty", "err", err)
-			}
-		}
-	}()
-	ch <- syscall.SIGWINCH // initial size
-	defer func() {
-		signal.Stop(ch)
-		close(ch)
-	}()
-
-	// put the ssh session's pty in raw mode
-	oldState, err := term.MakeRaw(int(ppty.Slave.Fd()))
-	if err != nil {
-		return fmt.Errorf("cmd: %w", err)
-	}
-	defer func() {
-		if err := term.Restore(int(ppty.Slave.Fd()), oldState); err != nil {
-			log.Error("could not restore terminal", "err", err)
-		}
-	}()
-
-	// we'll need to be able to cancel the reader, otherwise the copy
-	// from ptmx will eat the next keypress after the exec exits.
-	stdin, err := cancelreader.NewReader(ppty.Slave)
-	if err != nil {
-		return fmt.Errorf("cmd: %w", err)
-	}
-	defer func() { stdin.Cancel() }()
-
-	// sync io
-	go func() {
-		if _, err := io.Copy(ptmx, stdin); err != nil {
-			if errors.Is(err, io.EOF) || errors.Is(err, cancelreader.ErrCanceled) {
-				// safe to ignore
-				return
-			}
-			log.Warn("failed to copy", "err", err)
-		}
-	}()
-	if _, err := io.Copy(ppty.Slave, ptmx); err != nil {
-		if !errors.Is(err, io.EOF) && !errors.Is(err, syscall.EIO) {
-			return fmt.Errorf("cmd: copy: %w", err)
-		}
-		log.Warn("failed to copy", "err", err)
-	}
-
-	// TODO: check if this works on windows.
-	if runtime.GOOS == "windows" {
-		start := time.Now()
-		for c.cmd.ProcessState == nil {
-			if time.Since(start) > time.Second*10 {
-				return fmt.Errorf("could not start process")
-			}
-			time.Sleep(100 * time.Millisecond)
-		}
-		if !c.cmd.ProcessState.Success() {
-			return fmt.Errorf("process failed: exit %d", c.cmd.ProcessState.ExitCode())
-		}
-		return nil
-	}
-
-	return c.cmd.Wait()
+	return c.doRun(ppty)
 }
 
 var _ tea.ExecCommand = &Cmd{}

--- a/cmd.go
+++ b/cmd.go
@@ -127,8 +127,11 @@ func (c *Cmd) Run() error {
 			log.Warn("failed to copy", "err", err)
 		}
 	}()
-	if _, err := io.Copy(ppty.Slave, ptmx); err != nil && !errors.Is(err, io.EOF) {
-		return err
+	if _, err := io.Copy(ppty.Slave, ptmx); err != nil {
+		if !errors.Is(err, io.EOF) && !errors.Is(err, syscall.EIO) {
+			return fmt.Errorf("cmd: copy: %w", err)
+		}
+		log.Warn("failed to copy", "err", err)
 	}
 
 	// TODO: check if this works on windows.

--- a/cmd_darwin.go
+++ b/cmd_darwin.go
@@ -1,0 +1,89 @@
+//go:build darwin
+// +build darwin
+
+package wish
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/charmbracelet/log"
+	"github.com/charmbracelet/ssh"
+	"github.com/creack/pty"
+	"github.com/muesli/cancelreader"
+	"golang.org/x/term"
+)
+
+// on macOS, the slave pty is killed once exec finishes.
+// since we're using it for the ssh session, this would render
+// the pty and the session unusable.
+// so, we need to create another pty, and run the Cmd on it instead.
+func (c *Cmd) doRun(ppty ssh.Pty) error {
+	ptmx, err := pty.Start(c.cmd)
+	if err != nil {
+		return fmt.Errorf("cmd: %w", err)
+	}
+	defer func() {
+		if err := ptmx.Close(); err != nil {
+			log.Warn("could not close pty", "err", err)
+		}
+	}()
+
+	// setup resizes
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGWINCH)
+	go func() {
+		for range ch {
+			if err := pty.InheritSize(ppty.Master, ptmx); err != nil {
+				log.Warn("error resizing pty", "err", err)
+			}
+		}
+	}()
+	ch <- syscall.SIGWINCH // initial size
+	defer func() {
+		signal.Stop(ch)
+		close(ch)
+	}()
+
+	// put the ssh session's pty in raw mode
+	oldState, err := term.MakeRaw(int(ppty.Slave.Fd()))
+	if err != nil {
+		return fmt.Errorf("cmd: %w", err)
+	}
+	defer func() {
+		if err := term.Restore(int(ppty.Slave.Fd()), oldState); err != nil {
+			log.Error("could not restore terminal", "err", err)
+		}
+	}()
+
+	// we'll need to be able to cancel the reader, otherwise the copy
+	// from ptmx will eat the next keypress after the exec exits.
+	stdin, err := cancelreader.NewReader(ppty.Slave)
+	if err != nil {
+		return fmt.Errorf("cmd: %w", err)
+	}
+	defer func() { stdin.Cancel() }()
+
+	// sync io
+	go func() {
+		if _, err := io.Copy(ptmx, stdin); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, cancelreader.ErrCanceled) {
+				// safe to ignore
+				return
+			}
+			log.Warn("failed to copy", "err", err)
+		}
+	}()
+	if _, err := io.Copy(ppty.Slave, ptmx); err != nil {
+		if !errors.Is(err, io.EOF) && !errors.Is(err, syscall.EIO) {
+			return fmt.Errorf("cmd: copy: %w", err)
+		}
+		log.Warn("failed to copy", "err", err)
+	}
+
+	return c.cmd.Wait()
+}

--- a/cmd_darwin.go
+++ b/cmd_darwin.go
@@ -78,11 +78,8 @@ func (c *Cmd) doRun(ppty ssh.Pty) error {
 			log.Warn("failed to copy", "err", err)
 		}
 	}()
-	if _, err := io.Copy(ppty.Slave, ptmx); err != nil {
-		if !errors.Is(err, io.EOF) && !errors.Is(err, syscall.EIO) {
-			return fmt.Errorf("cmd: copy: %w", err)
-		}
-		log.Warn("failed to copy", "err", err)
+	if _, err := io.Copy(ppty.Slave, ptmx); err != nil && !errors.Is(err, io.EOF) {
+		return fmt.Errorf("cmd: copy: %w", err)
 	}
 
 	return c.cmd.Wait()

--- a/cmd_darwin.go
+++ b/cmd_darwin.go
@@ -6,9 +6,6 @@ package wish
 import (
 	"errors"
 	"io"
-	"os"
-	"os/signal"
-	"syscall"
 
 	"github.com/charmbracelet/log"
 	"github.com/charmbracelet/ssh"
@@ -21,32 +18,40 @@ import (
 // since we're using it for the ssh session, this would render
 // the pty and the session unusable.
 // so, we need to create another pty, and run the Cmd on it instead.
-func (c *Cmd) doRun(ppty ssh.Pty) error {
+func (c *Cmd) doRun(ppty ssh.Pty, winCh <-chan ssh.Window) error {
+	done := make(chan struct{}, 1)
+	go func() { <-done; close(done) }()
 	ptmx, err := pty.Start(c.cmd)
 	if err != nil {
 		return err
 	}
 	defer func() {
+		<-done
 		if err := ptmx.Close(); err != nil {
 			log.Warn("could not close pty", "err", err)
 		}
 	}()
 
 	// setup resizes
-	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, syscall.SIGWINCH)
 	go func() {
-		for range ch {
-			if err := pty.InheritSize(ppty.Master, ptmx); err != nil {
-				log.Warn("error resizing pty", "err", err)
+		for {
+			select {
+			case <-done:
+				return
+			case w := <-winCh:
+				log.Infof("resize %d %d", w.Height, w.Width)
+				if err := pty.Setsize(ptmx, &pty.Winsize{
+					Rows: uint16(w.Height),
+					Cols: uint16(w.Width),
+				}); err != nil {
+					log.Warn("could not set term size", "err", err)
+				}
 			}
 		}
 	}()
-	ch <- syscall.SIGWINCH // initial size
-	defer func() {
-		signal.Stop(ch)
-		close(ch)
-	}()
+	if err := pty.InheritSize(ppty.Slave, ptmx); err != nil {
+		return err
+	}
 
 	// put the ssh session's pty in raw mode
 	oldState, err := term.MakeRaw(int(ppty.Slave.Fd()))
@@ -65,17 +70,21 @@ func (c *Cmd) doRun(ppty ssh.Pty) error {
 	if err != nil {
 		return err
 	}
-	defer func() { stdin.Cancel(); stdin.Close() }()
+	defer func() {
+		stdin.Cancel()
+	}()
 
 	// sync io
 	go func() {
 		if _, err := io.Copy(ptmx, stdin); err != nil {
+			done <- struct{}{}
 			if errors.Is(err, io.EOF) || errors.Is(err, cancelreader.ErrCanceled) {
 				// safe to ignore
 				return
 			}
 			log.Warn("failed to copy", "err", err)
 		}
+		done <- struct{}{}
 	}()
 	if _, err := io.Copy(ppty.Slave, ptmx); err != nil && !errors.Is(err, io.EOF) {
 		return err

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -33,6 +33,9 @@ func TestCommandNoPty(t *testing.T) {
 }
 
 func TestCommandPty(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
 	tmp := t.TempDir()
 	srv := &ssh.Server{
 		Handler: func(s ssh.Session) {
@@ -64,6 +67,9 @@ func TestCommandPty(t *testing.T) {
 }
 
 func TestCommandPtyError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
 	srv := &ssh.Server{
 		Handler: func(s ssh.Session) {
 			if err := Command(s, "nopenopenope").Run(); err != nil {

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -42,6 +42,9 @@ func TestCommandPty(t *testing.T) {
 			runEcho(s, "hello")
 			runEnv(s, []string{"HELLO=world"})
 			runPwd(s, tmp)
+			// for some reason sometimes on macos github action runners,
+			// it cuts parts of the output.
+			time.Sleep(100 * time.Millisecond)
 		},
 	}
 	if err := ssh.AllocatePty()(srv); err != nil {

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/ssh"
 	"github.com/charmbracelet/wish/testsession"

--- a/cmd_unix.go
+++ b/cmd_unix.go
@@ -5,7 +5,7 @@ package wish
 
 import "github.com/charmbracelet/ssh"
 
-func (c *Cmd) doRun(ppty ssh.Pty) error {
+func (c *Cmd) doRun(ppty ssh.Pty, _ <-chan ssh.Window) error {
 	if err := ppty.Start(c.cmd); err != nil {
 		return err
 	}

--- a/cmd_unix.go
+++ b/cmd_unix.go
@@ -1,0 +1,13 @@
+//go:build dragonfly || freebsd || linux || netbsd || openbsd || solaris
+// +build dragonfly freebsd linux netbsd openbsd solaris
+
+package wish
+
+import "github.com/charmbracelet/ssh"
+
+func (c *Cmd) doRun(ppty ssh.Pty) error {
+	if err := ppty.Start(c.cmd); err != nil {
+		return err
+	}
+	return c.cmd.Wait()
+}

--- a/cmd_windows.go
+++ b/cmd_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+// +build windows
+
+package wish
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/charmbracelet/ssh"
+)
+
+func (c *Cmd) doRun(ppty ssh.Pty) error {
+	if err := ppty.Start(c.cmd); err != nil {
+		return err
+	}
+
+	start := time.Now()
+	for c.cmd.ProcessState == nil {
+		if time.Since(start) > time.Second*10 {
+			return fmt.Errorf("could not start process")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !c.cmd.ProcessState.Success() {
+		return fmt.Errorf("process failed: exit %d", c.cmd.ProcessState.ExitCode())
+	}
+	return nil
+}

--- a/cmd_windows.go
+++ b/cmd_windows.go
@@ -10,7 +10,7 @@ import (
 	"github.com/charmbracelet/ssh"
 )
 
-func (c *Cmd) doRun(ppty ssh.Pty) error {
+func (c *Cmd) doRun(ppty ssh.Pty, _ <-chan ssh.Window) error {
 	if err := ppty.Start(c.cmd); err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,13 +8,16 @@ require (
 	github.com/charmbracelet/lipgloss v0.9.1
 	github.com/charmbracelet/log v0.3.1
 	github.com/charmbracelet/ssh v0.0.0-20240118173142-6d7cf11c8371
+	github.com/creack/pty v1.1.21
 	github.com/go-git/go-git/v5 v5.11.0
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/matryer/is v1.4.1
+	github.com/muesli/cancelreader v0.2.2
 	github.com/muesli/termenv v0.15.2
 	golang.org/x/crypto v0.18.0
 	golang.org/x/sync v0.6.0
+	golang.org/x/term v0.16.0
 	golang.org/x/time v0.5.0
 )
 
@@ -28,7 +31,6 @@ require (
 	github.com/charmbracelet/x/exp/term v0.0.0-20240117031359-6e25c76a1efe // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
-	github.com/creack/pty v1.1.21 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
@@ -42,7 +44,6 @@ require (
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
-	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
@@ -54,7 +55,6 @@ require (
 	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
-	golang.org/x/term v0.16.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.14.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect


### PR DESCRIPTION
dirty fix to "inappropriate ioctl for device" on macOS.

It seems that macOS kills the slave pty once `exec.Cmd` finishes... so we need to create a new PTY just to run said program in order to avoid that problem.

Need to test, but this might make things possible on windows, too.