### PR TITLE
fix: remove ssh server version

### DIFF
--- a/wish.go
+++ b/wish.go
@@ -18,8 +18,6 @@ type Middleware func(next ssh.Handler) ssh.Handler
 // public key.
 func NewServer(ops ...ssh.Option) (*ssh.Server, error) {
 	s := &ssh.Server{}
-	// Some sensible defaults
-	s.Version = "OpenSSH_7.6p1"
 	for _, op := range ops {
 		if err := s.SetOption(op); err != nil {
 			return nil, err


### PR DESCRIPTION
Golang SSH will set a default version when this is empty, using "OpenSSH_7.6p1" is misleading and causes SSH clients to misidentify the server version.

Reference: https://pkg.go.dev/golang.org/x/crypto/ssh#:~:text=//%20%22SSH%2D2.0%2D%22.-,ServerVersion,-string%0A%0A%09//%20BannerCallback%2C%20if
Fixes: https://github.com/charmbracelet/soft-serve/issues/485