### PR TITLE
docs: fix broken link in examples readme

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -26,4 +26,4 @@ We recommend you follow the examples in the following order:
 ## Pseudo Terminals
 
 1. [Allocate a PTY](./pty)
-1. [Running Bubble Tea, and executing another program on an allocated PTY](./wish-exec)
+1. [Running Bubble Tea, and executing another program on an allocated PTY](./bubbletea-exec)


### PR DESCRIPTION
Hey, just noticed one of the links in `./examples/README.md` was pointing to the wrong directory.