### PR TITLE
fix(rename) NewDriver => NewReader

### DIFF
--- a/bubbletea/query.go
+++ b/bubbletea/query.go
@@ -59,7 +59,7 @@ func queryTerminal(
 	filter QueryTerminalFilter,
 	query string,
 ) error {
-	rd, err := input.NewDriver(in, "", 0)
+	rd, err := input.NewReader(in, "", 0)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
wish@v1.4.4/bubbletea/query.go:62:19: undefined: input.NewDriver as input@v0.3.0