### PR TITLE
fix: use renamed x/input type Reader

### DIFF
--- a/bubbletea/query.go
+++ b/bubbletea/query.go
@@ -59,7 +59,7 @@ func queryTerminal(
 	filter QueryTerminalFilter,
 	query string,
 ) error {
-	rd, err := input.NewDriver(in, "", 0)
+	rd, err := input.NewReader(in, "", 0)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The `input` package's `Driver` type in module [github.com/charmbracelet/x](https://github.com/charmbracelet/x) has been renamed to `Reader`. 

Modules depending on `github.com/charmbracelet/wish` currently [fail to build](https://github.com/charmbracelet/x/actions/runs/12261912092/job/34210011009) because of this.

This change adopts the newer name.