### PR TITLE
fix(tea): do not force color profile if session is not a PTY

### DIFF
--- a/bubbletea/tea.go
+++ b/bubbletea/tea.go
@@ -3,6 +3,7 @@ package bubbletea
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -115,9 +116,18 @@ func MakeRenderer(sess ssh.Session) *lipgloss.Renderer {
 	if !ok {
 		cp = termenv.Ascii
 	}
+
 	r := newRenderer(sess)
+
+	// We only force the color profile if the requested session is a PTY.
+	_, _, ok = sess.Pty()
+	if !ok {
+		return r
+	}
+
 	if r.ColorProfile() > cp {
-		wish.Printf(sess, "Warning: Client's terminal is %q, forcing %q\r\n", profileNames[r.ColorProfile()], profileNames[cp])
+		fmt.Fprintf(sess.Stderr(), "Warning: Client's terminal is %q, forcing %q\r\n", //nolint:errcheck
+			profileNames[r.ColorProfile()], profileNames[cp])
 		r.SetColorProfile(cp)
 	}
 	return r

--- a/bubbletea/tea.go
+++ b/bubbletea/tea.go
@@ -126,7 +126,7 @@ func MakeRenderer(sess ssh.Session) *lipgloss.Renderer {
 	}
 
 	if r.ColorProfile() > cp {
-		fmt.Fprintf(sess.Stderr(), "Warning: Client's terminal is %q, forcing %q\r\n", //nolint:errcheck
+		_, _ = fmt.Fprintf(sess.Stderr(), "Warning: Client's terminal is %q, forcing %q\r\n",
 			profileNames[r.ColorProfile()], profileNames[cp])
 		r.SetColorProfile(cp)
 	}


### PR DESCRIPTION
We only force the color profile if the requested session is a PTY. We also print warning messages to the client's stderr if we force a color profile.

Fixes: https://github.com/charmbracelet/soft-serve/issues/683