### PR TITLE
feat(v2): prevent suspending bubbletea

### DIFF
--- a/bubbletea/tea.go
+++ b/bubbletea/tea.go
@@ -90,7 +90,12 @@ func MiddlewareWithProgramHandler(handler ProgramHandler) wish.Middleware {
 // MakeOptions returns the tea.WithInput and tea.WithOutput program options
 // taking into account possible Emulated or Allocated PTYs.
 func MakeOptions(sess ssh.Session) []tea.ProgramOption {
-	return makeOpts(sess)
+	return append(makeOpts(sess), tea.WithFilter(func(_ tea.Model, msg tea.Msg) tea.Msg {
+		if _, ok := msg.(tea.SuspendMsg); ok {
+			return tea.ResumeMsg{}
+		}
+		return msg
+	}))
 }
 
 func newDefaultProgramHandler(handler Handler) ProgramHandler {

--- a/bubbletea/tea.go
+++ b/bubbletea/tea.go
@@ -104,6 +104,6 @@ func newDefaultProgramHandler(handler Handler) ProgramHandler {
 		if m == nil {
 			return nil
 		}
-		return tea.NewProgram(m, append(opts, makeOpts(s)...)...)
+		return tea.NewProgram(m, append(opts, MakeOptions(s)...)...)
 	}
 }


### PR DESCRIPTION
suspend would actually suspend the server instead of the connection.

ignoring suspend msgs, then users can type tilde-ctrl+z and it works as expected.