### PR TITLE
chore: migrate golangcilint to v2 config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,17 +1,6 @@
+version: "2"
 run:
   tests: false
-
-issues:
-  include:
-    - EXC0001
-    - EXC0005
-    - EXC0011
-    - EXC0012
-    - EXC0013
-
-  max-issues-per-linter: 0
-  max-same-issues: 0
-
 linters:
   enable:
     - bodyclose
@@ -20,8 +9,6 @@ linters:
     - goconst
     - godot
     - godox
-    - gofumpt
-    - goimports
     - goprintffuncname
     - gosec
     - misspell
@@ -32,11 +19,31 @@ linters:
     - unconvert
     - unparam
     - whitespace
-
-linters-settings:
-  depguard:
-    rules:
-      main:
-        deny:
-          - pkg: "github.com/gliderlabs/ssh"
-            desc: "use github.com/charmbracelet/ssh instead"
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: github.com/gliderlabs/ssh
+              desc: use github.com/charmbracelet/ssh instead
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
This commit migrates the existing golangci-lint config from v1 to v2 to keep up to date with the latest changes. No existing lints are fixed as part of this (as they are currently being ignored by CI) and can be taken care of separately to avoid mixing the config change with any code changes.

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [X] I have created a discussion that was approved by a maintainer (for new features).
