### PR TITLE
ci: use lint action from meta + add lint-sync

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,16 @@
-name: Build
+name: build
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:
   build:
     uses: charmbracelet/meta/.github/workflows/build.yml@main
+    secrets:
+      gh_pat: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
   codecov:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-sync.yml
+++ b/.github/workflows/lint-sync.yml
@@ -1,0 +1,14 @@
+name: lint-sync
+on:
+  schedule:
+    # every Sunday at midnight
+    - cron: "0 0 * * 0"
+  workflow_dispatch: # allows manual triggering
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  lint:
+    uses: charmbracelet/meta/.github/workflows/lint-sync.yml@main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,21 +1,12 @@
 name: lint
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:
-  golangci:
-    name: lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
-        with:
-          go-version: ^1
-          cache: true
-      - uses: golangci/golangci-lint-action@v8
-        with:
-          # Optional: golangci-lint command line arguments.
-          args: --issues-exit-code=0
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          only-new-issues: true
+  lint:
+    uses: charmbracelet/meta/.github/workflows/lint.yml@main
+    with:
+      golangci_path: .golangci.yml


### PR DESCRIPTION
Went checking because of #498, and realized our actions were out-of-date.