### PR TITLE
fix(cmd): respect SetStdin/SetStdout/SetStderr for tea.Exec compatibility

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -17,7 +17,7 @@ import (
 // itself.
 func CommandContext(ctx context.Context, s ssh.Session, name string, args ...string) *Cmd {
 	cmd := exec.CommandContext(ctx, name, args...)
-	return &Cmd{s, cmd}
+	return &Cmd{sess: s, cmd: cmd}
 }
 
 // Command sets stdin, stdout, and stderr to the current session's PTY.
@@ -32,8 +32,11 @@ func Command(s ssh.Session, name string, args ...string) *Cmd {
 
 // Cmd wraps a *exec.Cmd and a ssh.Pty so a command can be properly run.
 type Cmd struct {
-	sess ssh.Session
-	cmd  *exec.Cmd
+	sess   ssh.Session
+	cmd    *exec.Cmd
+	stdin  io.Reader
+	stdout io.Writer
+	stderr io.Writer
 }
 
 // SetEnv sets the underlying exec.Cmd env.
@@ -67,10 +70,16 @@ func (c *Cmd) Run() error {
 var _ tea.ExecCommand = &Cmd{}
 
 // SetStderr conforms with tea.ExecCommand.
-func (*Cmd) SetStderr(io.Writer) {}
+func (c *Cmd) SetStderr(w io.Writer) {
+	c.stderr = w
+}
 
 // SetStdin conforms with tea.ExecCommand.
-func (*Cmd) SetStdin(io.Reader) {}
+func (c *Cmd) SetStdin(r io.Reader) {
+	c.stdin = r
+}
 
 // SetStdout conforms with tea.ExecCommand.
-func (*Cmd) SetStdout(io.Writer) {}
+func (c *Cmd) SetStdout(w io.Writer) {
+	c.stdout = w
+}

--- a/cmd.go
+++ b/cmd.go
@@ -56,9 +56,22 @@ func (c *Cmd) SetDir(dir string) {
 
 // Run runs the program and waits for it to finish.
 func (c *Cmd) Run() error {
+	if c.hasCustomStdio() {
+		c.cmd.Stdin, c.cmd.Stdout, c.cmd.Stderr = c.stdin, c.stdout, c.stderr
+		return c.cmd.Run() //nolint:wrapcheck
+	}
 	ppty, winCh, ok := c.sess.Pty()
 	if !ok {
 		c.cmd.Stdin, c.cmd.Stdout, c.cmd.Stderr = c.sess, c.sess, c.sess.Stderr()
+		if c.stdin != nil {
+			c.cmd.Stdin = c.stdin
+		}
+		if c.stdout != nil {
+			c.cmd.Stdout = c.stdout
+		}
+		if c.stderr != nil {
+			c.cmd.Stderr = c.stderr
+		}
 		if err := c.cmd.Run(); err != nil {
 			return fmt.Errorf("run command: %w", err)
 		}
@@ -67,19 +80,30 @@ func (c *Cmd) Run() error {
 	return c.doRun(ppty, winCh)
 }
 
+// hasCustomStdio reports whether all three stdio handles were set, e.g. by
+// tea.Exec. The gate is all-or-nothing: a partial set keeps the default
+// session/PTY wiring, since ppty.Start cannot mix custom handles with the
+// PTY slave.
+func (c *Cmd) hasCustomStdio() bool {
+	return c.stdin != nil && c.stdout != nil && c.stderr != nil
+}
+
 var _ tea.ExecCommand = &Cmd{}
 
-// SetStderr conforms with tea.ExecCommand.
+// SetStderr conforms with tea.ExecCommand. It must be called before Run;
+// Cmd is not safe for concurrent use.
 func (c *Cmd) SetStderr(w io.Writer) {
 	c.stderr = w
 }
 
-// SetStdin conforms with tea.ExecCommand.
+// SetStdin conforms with tea.ExecCommand. It must be called before Run;
+// Cmd is not safe for concurrent use.
 func (c *Cmd) SetStdin(r io.Reader) {
 	c.stdin = r
 }
 
-// SetStdout conforms with tea.ExecCommand.
+// SetStdout conforms with tea.ExecCommand. It must be called before Run;
+// Cmd is not safe for concurrent use.
 func (c *Cmd) SetStdout(w io.Writer) {
 	c.stdout = w
 }

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -102,14 +102,14 @@ func TestCommandPtyError(t *testing.T) {
 // properly store custom I/O handles. This is important for tea.Exec integration
 // where Bubble Tea sets these to share I/O with the child process.
 func TestCommandSetStdio(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Windows requires all stdio to be set")
-	}
 	srv := &ssh.Server{
 		Handler: func(s ssh.Session) {
 			cmd := Command(s, "echo", "custom")
 			var buf bytes.Buffer
+			// Set all stdio handles (required for custom stdio path)
+			cmd.SetStdin(strings.NewReader(""))
 			cmd.SetStdout(&buf)
+			cmd.SetStderr(&buf)
 			if err := cmd.Run(); err != nil {
 				Fatal(s, err)
 			}

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -98,27 +98,30 @@ func TestCommandPtyError(t *testing.T) {
 	}
 }
 
-// TestCommandSetStdio verifies that SetStdin, SetStdout, SetStderr methods
-// properly store custom I/O handles. This is important for tea.Exec integration
-// where Bubble Tea sets these to share I/O with the child process.
+// TestCommandSetStdio verifies that Run uses the custom handles when all
+// three are set. The cat round trip proves both stdin and stdout flow
+// through: output can only appear in the buffer if both are wired.
 func TestCommandSetStdio(t *testing.T) {
 	srv := &ssh.Server{
 		Handler: func(s ssh.Session) {
-			cmd := Command(s, "echo", "custom")
-			var buf bytes.Buffer
-			// Set all stdio handles (required for custom stdio path)
-			cmd.SetStdin(strings.NewReader(""))
-			cmd.SetStdout(&buf)
-			cmd.SetStderr(&buf)
+			cmd := Command(s, "cat")
+			if runtime.GOOS == "windows" {
+				cmd = Command(s, "findstr", "roundtrip")
+			}
+			var out, errOut bytes.Buffer
+			cmd.SetStdin(strings.NewReader("roundtrip\n"))
+			cmd.SetStdout(&out)
+			cmd.SetStderr(&errOut)
 			if err := cmd.Run(); err != nil {
 				Fatal(s, err)
 			}
-			// Verify that output went to our custom buffer
-			if !strings.Contains(buf.String(), "custom") {
-				Fatal(s, "expected output in custom buffer")
+			if !strings.Contains(out.String(), "roundtrip") {
+				Fatalf(s, "expected stdin to round trip through custom stdout, got %q", out.String())
 			}
-			// Write success marker to session
 			_, _ = s.Write([]byte("SUCCESS"))
+			// for some reason sometimes on macos github action runners,
+			// it cuts parts of the output.
+			time.Sleep(100 * time.Millisecond)
 		},
 	}
 	if err := ssh.AllocatePty()(srv); err != nil {
@@ -138,12 +141,54 @@ func TestCommandSetStdio(t *testing.T) {
 	expectContains(t, stdout.String(), "SUCCESS")
 }
 
+// TestCommandSetStdioPartial verifies that a partial set keeps the default
+// PTY wiring: the gate is all-or-nothing.
+func TestCommandSetStdioPartial(t *testing.T) {
+	srv := &ssh.Server{
+		Handler: func(s ssh.Session) {
+			cmd := Command(s, "echo", "partial")
+			if runtime.GOOS == "windows" {
+				cmd = Command(s, "cmd", "/C", "echo", "partial")
+			}
+			// Only stdout is set, so the command must still run on the PTY
+			// and the session must see the output.
+			var sink bytes.Buffer
+			cmd.SetStdout(&sink)
+			if err := cmd.Run(); err != nil {
+				Fatal(s, err)
+			}
+			if sink.Len() != 0 {
+				Fatalf(s, "expected PTY fallback with partial stdio set, but output went to custom stdout: %q", sink.String())
+			}
+			// for some reason sometimes on macos github action runners,
+			// it cuts parts of the output.
+			time.Sleep(100 * time.Millisecond)
+		},
+	}
+	if err := ssh.AllocatePty()(srv); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	sess := testsession.New(t, srv, nil)
+	if err := sess.RequestPty("xterm", 500, 200, nil); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var stdout bytes.Buffer
+	sess.Stdout = &stdout
+	if err := sess.Run(""); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	expectContains(t, stdout.String(), "partial")
+}
+
 func runEcho(s ssh.Session, str string) {
 	cmd := Command(s, "echo", str)
 	if runtime.GOOS == "windows" {
 		cmd = Command(s, "cmd", "/C", "echo", str)
 	}
-	// Setting nil should be safe and not change behavior
+	// With all handles nil, the gate stays closed and the command runs on
+	// the session/PTY as before.
 	cmd.SetStderr(nil)
 	cmd.SetStdin(nil)
 	cmd.SetStdout(nil)

--- a/cmd_unix.go
+++ b/cmd_unix.go
@@ -6,28 +6,17 @@ package wish
 import "charm.land/ssh"
 
 func (c *Cmd) doRun(ppty ssh.Pty, _ <-chan ssh.Window) error {
-	// If custom stdio was set (e.g., by tea.Exec), use it instead of PTY slave.
+	// If ALL custom stdio are set (e.g., by tea.Exec), use them instead of PTY.
 	// This ensures proper sequencing of alt screen escape sequences when using
 	// tea.Exec with bubbletea.Middleware.
-	if c.stdin != nil || c.stdout != nil || c.stderr != nil {
-		if c.stdin != nil {
-			c.cmd.Stdin = c.stdin
-		} else {
-			c.cmd.Stdin = ppty.Slave
-		}
-		if c.stdout != nil {
-			c.cmd.Stdout = c.stdout
-		} else {
-			c.cmd.Stdout = ppty.Slave
-		}
-		if c.stderr != nil {
-			c.cmd.Stderr = c.stderr
-		} else {
-			c.cmd.Stderr = ppty.Slave
-		}
+	// We require all three to be set to avoid deadlocks with partial PTY usage.
+	if c.stdin != nil && c.stdout != nil && c.stderr != nil {
+		c.cmd.Stdin = c.stdin
+		c.cmd.Stdout = c.stdout
+		c.cmd.Stderr = c.stderr
 		return c.cmd.Run()
 	}
-	// Original behavior: use PTY slave for all stdio via ppty.Start()
+	// Original behavior: use PTY for all stdio via ppty.Start()
 	if err := ppty.Start(c.cmd); err != nil {
 		return err //nolint:wrapcheck
 	}

--- a/cmd_unix.go
+++ b/cmd_unix.go
@@ -6,17 +6,6 @@ package wish
 import "charm.land/ssh"
 
 func (c *Cmd) doRun(ppty ssh.Pty, _ <-chan ssh.Window) error {
-	// If ALL custom stdio are set (e.g., by tea.Exec), use them instead of PTY.
-	// This ensures proper sequencing of alt screen escape sequences when using
-	// tea.Exec with bubbletea.Middleware.
-	// We require all three to be set to avoid deadlocks with partial PTY usage.
-	if c.stdin != nil && c.stdout != nil && c.stderr != nil {
-		c.cmd.Stdin = c.stdin
-		c.cmd.Stdout = c.stdout
-		c.cmd.Stderr = c.stderr
-		return c.cmd.Run()
-	}
-	// Original behavior: use PTY for all stdio via ppty.Start()
 	if err := ppty.Start(c.cmd); err != nil {
 		return err //nolint:wrapcheck
 	}

--- a/cmd_unix.go
+++ b/cmd_unix.go
@@ -6,6 +6,28 @@ package wish
 import "charm.land/ssh"
 
 func (c *Cmd) doRun(ppty ssh.Pty, _ <-chan ssh.Window) error {
+	// If custom stdio was set (e.g., by tea.Exec), use it instead of PTY slave.
+	// This ensures proper sequencing of alt screen escape sequences when using
+	// tea.Exec with bubbletea.Middleware.
+	if c.stdin != nil || c.stdout != nil || c.stderr != nil {
+		if c.stdin != nil {
+			c.cmd.Stdin = c.stdin
+		} else {
+			c.cmd.Stdin = ppty.Slave
+		}
+		if c.stdout != nil {
+			c.cmd.Stdout = c.stdout
+		} else {
+			c.cmd.Stdout = ppty.Slave
+		}
+		if c.stderr != nil {
+			c.cmd.Stderr = c.stderr
+		} else {
+			c.cmd.Stderr = ppty.Slave
+		}
+		return c.cmd.Run()
+	}
+	// Original behavior: use PTY slave for all stdio via ppty.Start()
 	if err := ppty.Start(c.cmd); err != nil {
 		return err //nolint:wrapcheck
 	}

--- a/cmd_windows.go
+++ b/cmd_windows.go
@@ -11,6 +11,18 @@ import (
 )
 
 func (c *Cmd) doRun(ppty ssh.Pty, _ <-chan ssh.Window) error {
+	// If custom stdio was set (e.g., by tea.Exec), use it instead of PTY.
+	// This ensures proper sequencing of alt screen escape sequences when using
+	// tea.Exec with bubbletea.Middleware.
+	// On Windows, we only use the custom path if all stdio are set, since
+	// there's no ppty.Slave to fall back to for individual handles.
+	if c.stdin != nil && c.stdout != nil && c.stderr != nil {
+		c.cmd.Stdin = c.stdin
+		c.cmd.Stdout = c.stdout
+		c.cmd.Stderr = c.stderr
+		return c.cmd.Run()
+	}
+	// Original behavior: use PTY slave for all stdio via ppty.Start()
 	if err := ppty.Start(c.cmd); err != nil {
 		return err //nolint:wrapcheck
 	}

--- a/cmd_windows.go
+++ b/cmd_windows.go
@@ -4,10 +4,10 @@
 package wish
 
 import (
-	"fmt"
-	"time"
+	"context"
 
 	"charm.land/ssh"
+	"github.com/charmbracelet/x/xpty"
 )
 
 func (c *Cmd) doRun(ppty ssh.Pty, _ <-chan ssh.Window) error {
@@ -22,20 +22,11 @@ func (c *Cmd) doRun(ppty ssh.Pty, _ <-chan ssh.Window) error {
 		c.cmd.Stderr = c.stderr
 		return c.cmd.Run()
 	}
-	// Original behavior: use PTY slave for all stdio via ppty.Start()
+	// Original behavior: use PTY for all stdio via ppty.Start()
 	if err := ppty.Start(c.cmd); err != nil {
 		return err //nolint:wrapcheck
 	}
-
-	start := time.Now()
-	for c.cmd.ProcessState == nil {
-		if time.Since(start) > time.Second*10 {
-			return fmt.Errorf("could not start process")
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	if !c.cmd.ProcessState.Success() {
-		return fmt.Errorf("process failed: exit %d", c.cmd.ProcessState.ExitCode())
-	}
-	return nil
+	// Use xpty.WaitProcess for cross-platform process waiting.
+	// On Windows, cmd.Wait() doesn't work correctly with ConPTY.
+	return xpty.WaitProcess(context.Background(), c.cmd)
 }

--- a/cmd_windows.go
+++ b/cmd_windows.go
@@ -4,29 +4,15 @@
 package wish
 
 import (
-	"context"
-
 	"charm.land/ssh"
 	"github.com/charmbracelet/x/xpty"
 )
 
 func (c *Cmd) doRun(ppty ssh.Pty, _ <-chan ssh.Window) error {
-	// If custom stdio was set (e.g., by tea.Exec), use it instead of PTY.
-	// This ensures proper sequencing of alt screen escape sequences when using
-	// tea.Exec with bubbletea.Middleware.
-	// On Windows, we only use the custom path if all stdio are set, since
-	// there's no ppty.Slave to fall back to for individual handles.
-	if c.stdin != nil && c.stdout != nil && c.stderr != nil {
-		c.cmd.Stdin = c.stdin
-		c.cmd.Stdout = c.stdout
-		c.cmd.Stderr = c.stderr
-		return c.cmd.Run()
-	}
-	// Original behavior: use PTY for all stdio via ppty.Start()
 	if err := ppty.Start(c.cmd); err != nil {
 		return err //nolint:wrapcheck
 	}
-	// Use xpty.WaitProcess for cross-platform process waiting.
-	// On Windows, cmd.Wait() doesn't work correctly with ConPTY.
-	return xpty.WaitProcess(context.Background(), c.cmd)
+	// cmd.Wait() doesn't work with ConPTY; xpty.WaitProcess waits on the
+	// process directly and honors the session context for cancellation.
+	return xpty.WaitProcess(c.sess.Context(), c.cmd) //nolint:wrapcheck
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	charm.land/log/v2 v2.0.0
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/keygen v0.5.4
-	github.com/charmbracelet/x/xpty v0.1.3
+	github.com/charmbracelet/x/xpty v0.1.4
 	github.com/go-git/go-git/v5 v5.19.2
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	charm.land/log/v2 v2.0.0
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/keygen v0.5.4
+	github.com/charmbracelet/x/xpty v0.1.3
 	github.com/go-git/go-git/v5 v5.19.2
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8
 github.com/charmbracelet/x/termios v0.1.1/go.mod h1:rB7fnv1TgOPOyyKRJ9o+AsTU/vK5WHJ2ivHeut/Pcwo=
 github.com/charmbracelet/x/windows v0.2.2 h1:IofanmuvaxnKHuV04sC0eBy/smG6kIKrWG2/jYn2GuM=
 github.com/charmbracelet/x/windows v0.2.2/go.mod h1:/8XtdKZzedat74NQFn0NGlGL4soHB0YQZrETF96h75k=
+github.com/charmbracelet/x/xpty v0.1.3 h1:eGSitii4suhzrISYH50ZfufV3v085BXQwIytcOdFSsw=
+github.com/charmbracelet/x/xpty v0.1.3/go.mod h1:poPYpWuLDBFCKmKLDnhBp51ATa0ooD8FhypRwEFtH3Y=
 github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSEFgwIwO+UVM8=
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8
 github.com/charmbracelet/x/termios v0.1.1/go.mod h1:rB7fnv1TgOPOyyKRJ9o+AsTU/vK5WHJ2ivHeut/Pcwo=
 github.com/charmbracelet/x/windows v0.2.2 h1:IofanmuvaxnKHuV04sC0eBy/smG6kIKrWG2/jYn2GuM=
 github.com/charmbracelet/x/windows v0.2.2/go.mod h1:/8XtdKZzedat74NQFn0NGlGL4soHB0YQZrETF96h75k=
-github.com/charmbracelet/x/xpty v0.1.3 h1:eGSitii4suhzrISYH50ZfufV3v085BXQwIytcOdFSsw=
-github.com/charmbracelet/x/xpty v0.1.3/go.mod h1:poPYpWuLDBFCKmKLDnhBp51ATa0ooD8FhypRwEFtH3Y=
+github.com/charmbracelet/x/xpty v0.1.4 h1:4jaW7u+8AHQMxesiVc+zUMsspu7GyDwtJO+gy/tFtW4=
+github.com/charmbracelet/x/xpty v0.1.4/go.mod h1:7t8P7BpPiolHJ1pLzz7/4ujDbD+sUxI9yA3CBOLOIcU=
 github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSEFgwIwO+UVM8=
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=


### PR DESCRIPTION

This PR fixes issue #506 where Bubble Tea programs running under Wish's `bubbletea.Middleware` with `ssh.AllocatePty()` would not properly release the alternate screen when executing child processes via `tea.Exec`.

## Problem
When using `tea.Exec` with `wish.Command`, the child process output appeared "stacked" below the TUI instead of replacing it. This happened because `wish.Cmd`'s [SetStdin](cci:1:wish/cmd.go:71:0-74:1), [SetStdout](cci:1: wish/cmd.go:76:0-79:1), and [SetStderr](cci:1:wish/cmd.go:66:0-69:1) methods were no-ops, causing Bubble Tea's alt screen escape sequences to be written to a different output path than the child process.

## Solution
Modified `wish.Cmd` to properly store and use the I/O handles set by Bubble Tea's exec flow:
- Added `stdin`, `stdout`, `stderr` fields to [Cmd](cci:2 /wish/cmd.go:31:0-37:1) struct
- Implemented [SetStdin](cci:1 /wish/cmd.go:71:0-74:1), [SetStdout](cci: wish/cmd.go:76:0-79:1), [SetStderr](cci:1/wish/cmd.go:66:0-69:1) to store values
- Updated [doRun()](cci: wish/cmd_unix.go:7:0-34:1) to use custom I/O when set, falling back to PTY otherwise

## Changes
- [cmd.go](cci:7: /wish/cmd.go:0:0-0:0) - Added stdio fields and implemented Set* methods
- [cmd_unix.go](cci:7: wish/cmd_unix.go:0:0-0:0) - Use custom I/O when any handle is set
- [cmd_windows.go](cci:7:wish/cmd_windows.go:0:0-0:0) - Use custom I/O when ALL handles are set (no `ppty.Slave` on Windows)
- [cmd_test.go](cci:7: wish/cmd_test.go:0:0-0:0) - Added [TestCommandSetStdio](cci:1: wish/cmd_test.go:100:0-138:1) to verify the fix

## Testing
- All existing tests pass
- Added new test [TestCommandSetStdio](cci:1: wish/cmd_test.go:100:0-138:1) that verifies custom I/O handles are used

## Before/After
**Before:** Child process output appears below TUI frame; scrollback shows "stacked" output  
**After:** Child process replaces TUI cleanly; alt screen properly exits/enters around exec

Fixes #506