### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -163,7 +163,7 @@ func fileExists(path string) (bool, error) {
 }
 
 // Fatal prints to the session's STDOUT as a git response and exit 1.
-func Fatal(s ssh.Session, v ...interface{}) {
+func Fatal(s ssh.Session, v ...any) {
 	msg := fmt.Sprint(v...)
 	// hex length includes 4 byte length prefix and ending newline
 	pktLine := fmt.Sprintf("%04x%s\n", len(msg)+5, msg)

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -21,7 +21,7 @@ func Middleware() wish.Middleware {
 
 // Logger is the interface that wraps the basic Log method.
 type Logger interface {
-	Printf(format string, v ...interface{})
+	Printf(format string, v ...any)
 }
 
 // MiddlewareWithLogger provides basic connection logging.

--- a/options_test.go
+++ b/options_test.go
@@ -214,7 +214,7 @@ func getBytes(tb testing.TB, path string) []byte {
 	return bts
 }
 
-func requireEqual(tb testing.TB, a, b interface{}) {
+func requireEqual(tb testing.TB, a, b any) {
 	tb.Helper()
 	if a != b {
 		tb.Fatalf("expected %v, got %v", a, b)

--- a/recover/recover.go
+++ b/recover/recover.go
@@ -16,7 +16,7 @@ func Middleware(mw ...wish.Middleware) wish.Middleware {
 
 // Logger is the interface that wraps the basic Log method.
 type Logger interface {
-	Printf(format string, v ...interface{})
+	Printf(format string, v ...any)
 }
 
 // MiddlewareWithLogger is a wish middleware that recovers from panics and log to

--- a/wish.go
+++ b/wish.go
@@ -37,7 +37,7 @@ func NewServer(ops ...ssh.Option) (*ssh.Server, error) {
 }
 
 // Fatal prints to the given session's STDERR and exits 1.
-func Fatal(s ssh.Session, v ...interface{}) {
+func Fatal(s ssh.Session, v ...any) {
 	Error(s, v...)
 	_ = s.Exit(1)
 	_ = s.Close()
@@ -47,7 +47,7 @@ func Fatal(s ssh.Session, v ...interface{}) {
 // followed by an exit 1.
 //
 // Notice that this might cause formatting issues if you don't add a \r\n in the end of your string.
-func Fatalf(s ssh.Session, f string, v ...interface{}) {
+func Fatalf(s ssh.Session, f string, v ...any) {
 	Errorf(s, f, v...)
 	_ = s.Exit(1)
 	_ = s.Close()
@@ -55,7 +55,7 @@ func Fatalf(s ssh.Session, f string, v ...interface{}) {
 
 // Fatalln formats according to the default format, prints to the session's
 // STDERR, followed by a new line and an exit 1.
-func Fatalln(s ssh.Session, v ...interface{}) {
+func Fatalln(s ssh.Session, v ...any) {
 	Errorln(s, v...)
 	Errorf(s, "\r")
 	_ = s.Exit(1)
@@ -63,32 +63,32 @@ func Fatalln(s ssh.Session, v ...interface{}) {
 }
 
 // Error prints the given error the the session's STDERR.
-func Error(s ssh.Session, v ...interface{}) {
+func Error(s ssh.Session, v ...any) {
 	_, _ = fmt.Fprint(s.Stderr(), v...)
 }
 
 // Errorf formats according to the given format and prints to the session's STDERR.
-func Errorf(s ssh.Session, f string, v ...interface{}) {
+func Errorf(s ssh.Session, f string, v ...any) {
 	_, _ = fmt.Fprintf(s.Stderr(), f, v...)
 }
 
 // Errorln formats according to the default format and prints to the session's STDERR.
-func Errorln(s ssh.Session, v ...interface{}) {
+func Errorln(s ssh.Session, v ...any) {
 	_, _ = fmt.Fprintln(s.Stderr(), v...)
 }
 
 // Print writes to the session's STDOUT followed.
-func Print(s ssh.Session, v ...interface{}) {
+func Print(s ssh.Session, v ...any) {
 	_, _ = fmt.Fprint(s, v...)
 }
 
 // Printf formats according to the given format and writes to the session's STDOUT.
-func Printf(s ssh.Session, f string, v ...interface{}) {
+func Printf(s ssh.Session, f string, v ...any) {
 	_, _ = fmt.Fprintf(s, f, v...)
 }
 
 // Println formats according to the default format and writes to the session's STDOUT.
-func Println(s ssh.Session, v ...interface{}) {
+func Println(s ssh.Session, v ...any) {
 	_, _ = fmt.Fprintln(s, v...)
 }
 


### PR DESCRIPTION
Replaces `interface{}` with `any` (Go 1.18+ alias) across 5 files:
- wish.go
- recover/recover.go
- git/git.go
- logging/logging.go
- options_test.go