### PR TITLE
fix(examples/multichat): fix textarea.Update call for value receiver of textarea.Model

### DIFF
--- a/examples/multichat/main.go
+++ b/examples/multichat/main.go
@@ -109,7 +109,7 @@ type model struct {
 	viewport    viewport.Model
 	messages    []string
 	id          string
-	textarea    *textarea.Model
+	textarea    textarea.Model
 	senderStyle lipgloss.Style
 	err         error
 }


### PR DESCRIPTION
**Contributing Guidelines**
--
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
 - This is a bug fix, so no prior discussion is required.   

**Steps to reproduce**
--
```
cd examples/multichat
go run .
```

### Errors

``` text
./main.go:142:16: cannot use ta (variable of struct type textarea.Model) as *textarea.Model value in struct literal
./main.go:160:22: cannot use m.textarea.Update(msg) (value of struct type textarea.Model) as *textarea.Model value in assignment
```


The example fails to compile because ```textarea.Model.Update``` expects a value receiver of ```textarea.Model ```.

**Solution**
--
In the main ```model``` struct, the field ```textarea``` is a pointer ```*textarea.Model```, the fix is to change the type of ```textarea``` to be the struct ```textarea.Model``` instead.